### PR TITLE
csl refs fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .Rproj.user
 .Rhistory
 .RData
+*DS_Store

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cogsci2016
 Title: Create CogSci Proceedings Submission with RMarkdown
-Version: 1.0.0.0
+Version: 1.0.0.1
 Authors@R: person("Kyle", "MacDonald", email = "kylem412@gmail.com", role = c("aut", "cre"))
 Description: Cogsci2016 provides an R Markdown LaTeX format and template for
     authoring a CogSci conference submission.
@@ -16,4 +16,4 @@ Imports:
     yaml (>= 2.1.19),
     rmarkdown (>= 0.3.10),
     knitr (>= 1.10.5)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.0

--- a/inst/rmarkdown/templates/cogsci_paper_2016/resources/template.tex
+++ b/inst/rmarkdown/templates/cogsci_paper_2016/resources/template.tex
@@ -62,6 +62,15 @@ $for(author-information)$
 $author-information$
 $endfor$
 
+$if(csl-refs)$
+\newlength{\cslhangindent}
+\setlength{\cslhangindent}{1.5em}
+\newenvironment{cslreferences}%
+  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
+  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
+  {\par}
+$endif$
+
 \begin{document}
 
 \maketitle

--- a/man/pdf_document.Rd
+++ b/man/pdf_document.Rd
@@ -4,11 +4,23 @@
 \alias{pdf_document}
 \title{Convert to a PDF document}
 \usage{
-pdf_document(toc = FALSE, toc_depth = 2, number_sections = FALSE,
-  fig_width = 6.5, fig_height = 4.5, fig_crop = TRUE,
-  fig_caption = FALSE, dev = "pdf", highlight = "default",
-  template = "default", keep_tex = FALSE, latex_engine = "pdflatex",
-  includes = NULL, md_extensions = NULL, pandoc_args = NULL)
+pdf_document(
+  toc = FALSE,
+  toc_depth = 2,
+  number_sections = FALSE,
+  fig_width = 6.5,
+  fig_height = 4.5,
+  fig_crop = TRUE,
+  fig_caption = FALSE,
+  dev = "pdf",
+  highlight = "default",
+  template = "default",
+  keep_tex = FALSE,
+  latex_engine = "pdflatex",
+  includes = NULL,
+  md_extensions = NULL,
+  pandoc_args = NULL
+)
 }
 \arguments{
 \item{toc}{\code{TRUE} to include a table of contents in the output}


### PR DESCRIPTION
Fixed an issue that prevented knitting to some changes in pandoc. Basically, just added the following code to the .tex template:

$if(csl-refs)$
\newlength{\cslhangindent}
\setlength{\cslhangindent}{1.5em}
\newenvironment{cslreferences}%
  {$if(csl-hanging-indent)$\setlength{\parindent}{0pt}%
  \everypar{\setlength{\hangindent}{\cslhangindent}}\ignorespaces$endif$}%
  {\par}
$endif$

see here: https://github.com/crsh/papaja/issues/368